### PR TITLE
Bump node-inspector version

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Number of stack frames to show on a breakpoint.
 
 # Changelog
 
+**0.1.3** - Bumped node-inspector version to ~0.7.0, adding `--no-preload` option for faster loading.
+
 **0.1.2** - Bumped node-inspector version to ~0.6.0, adding the new `--stack-trace-limit` option. Allowed node-inspector to be listed as a dependency in a project's package.json instead of forcing it to be in grunt-node-inspector's node_modules folder.
 
 **0.1.1** - Bumped node-inspector version to ~0.5.0.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-node-inspector",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Run node-inspector with the rest of your workflow to debug node.js",
   "main": "tasks/index.js",
   "scripts": {
@@ -19,10 +19,10 @@
   "author": "ChrisWren",
   "license": "MIT",
   "peerDependencies": {
-    "grunt": "~0.4.1"
+    "grunt": "~0.4.2"
   },
   "devDependencies": {
-    "grunt": "~0.4.1",
+    "grunt": "~0.4.2",
     "grunt-release": "~0.5.1",
     "grunt-contrib-jshint": "~0.6.2",
     "matchdep": "~0.1.2",
@@ -31,6 +31,6 @@
     "grunt-simple-mocha": "~0.4.0"
   },
   "dependencies": {
-    "node-inspector": "~0.6.0"
+    "node-inspector": "~0.7.0"
   }
 }

--- a/tasks/inspector.js
+++ b/tasks/inspector.js
@@ -19,7 +19,8 @@ module.exports = function (grunt) {
       'debug-port',
       'save-live-edit',
       'readTimeout',
-      'stack-trace-limit'
+      'stack-trace-limit',
+      'no-preload'
     ].forEach(function (option) {
       if (option in options) {
         args.push('--' + option);


### PR DESCRIPTION
Node-inspector performance improved in 0.7.0 just bumped the npm version.
