### PR TITLE
Bump node-inspector to ^0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Array of files to hide from the UI (breakpoints in these files will be ignored).
 
 # Changelog
 
+**0.1.6** - Bumped node-inspector version to ^0.9.0 (compatible with latest Chrome updates).
+
 **0.1.5** - Added `--hidden` option for hiding certain files/directories.
 
 **0.1.3** - Bumped node-inspector version to ~0.7.0, adding `--no-preload` option for faster loading.

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "matchdep": "~0.1.2",
     "grunt-mdlint": "0.0.0",
     "should": "~2.1.0",
-    "grunt-simple-mocha": "~0.4.0"
+    "grunt-simple-mocha": "~0.4.0",
+    "win-spawn": "^2.0.0"
   },
   "dependencies": {
     "node-inspector": "~0.7.0"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "win-spawn": "^2.0.0"
   },
   "dependencies": {
-    "node-inspector": "~0.7.0"
+    "node-inspector": "^0.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-node-inspector",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Run node-inspector with the rest of your workflow to debug node.js",
   "main": "tasks/inspector.js",
   "scripts": {

--- a/test/integrationTests.js
+++ b/test/integrationTests.js
@@ -1,6 +1,6 @@
 /*jshint node: true, expr: true*/
 /*global describe, before, it*/
-var spawn = require('child_process').spawn;
+var spawn = process.platform === 'win32' ? require('win-spawn') : require('child_process').spawn;
 var logOutput = '';
 require('should');
 


### PR DESCRIPTION
Bump node-inspector to ^0.9.0 to be compatible with the latest Chrome update (otherwise cannot evaluate and display nested values). Also make tests Windows friendly using win-spawn (new dev dependency).

Closes #22 