### PR TITLE
Update/fix options parsing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,28 @@ Here is a config that uses all of the available options for node-inspector:
 'node-inspector': {
   custom: {
     options: {
-      'web-port': 1337,
       'web-host': 'localhost',
+      'web-port': 1337,
       'debug-port': 5857,
       'save-live-edit': true,
-      'no-preload': true,
+      'preload': false,
+      'hidden': ['node_modules'],
       'stack-trace-limit': 4,
-      'hidden': ['node_modules']
+    }
+  }
+}
+```
+
+To start node-inspector to listen over HTTPS, use the `ssl-key` and `ssl-cert` options:
+
+'node-inspector': {
+  custom: {
+    options: {
+      'web-host': 'localhost',
+      'web-port': 1337,
+      'debug-port': 5857,
+      'ssl-key': './ssl/key.pem',
+      'ssl-cert': './ssl/cert.pem'
     }
   }
 }
@@ -75,11 +90,11 @@ Type: `Boolean` Default: false
 
 Save live edit changes to disk.
 
-#### no-preload
+#### preload
 
-Type: `Boolean` Default: false
+Type: `Boolean` Default: true
 
-Disables preloading *.js to speed up startup
+Enables preloading *.js files. Set to `false` to speed up startup
 
 #### stack-trace-limit
 
@@ -92,6 +107,18 @@ Number of stack frames to show on a breakpoint.
 Type: `Array` Default: []
 
 Array of files to hide from the UI (breakpoints in these files will be ignored).
+
+#### ssl-key
+
+Type: `String` Default: ''
+
+A file containing a valid SSL key for starting inspector listening over HTTPS.
+
+#### ssl-cert
+
+Type: `String` Default: ''
+
+A file containing a valid SSL certificate for starting inspector listening over HTTPS.
 
 # Changelog
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ A file containing a valid SSL certificate for starting inspector listening over 
 
 # Changelog
 
+**0.4.0** - Changed `no-preload` option to `preload`. Fixed `hidden` option parsing. Added SSL options.
+
+**Breaking changes:**
+
+options['no-preload'] is now options.preload. If you previously set `no-preload` to `true`, you should change your gruntfile to set `preload` to `false`.
+
 **0.3.0** - Bumped node-inspector version to ^0.12.3.
 
 **0.2.0** - Bumped node-inspector version to ^0.10.0.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-node-inspector",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Run node-inspector with the rest of your workflow to debug node.js",
   "main": "tasks/inspector.js",
   "scripts": {

--- a/tasks/inspector.js
+++ b/tasks/inspector.js
@@ -6,29 +6,38 @@
  * Licensed under the MIT license.
  */
 /*jshint node: true*/
+
 module.exports = function (grunt) {
   'use strict';
+  var util = require('util');
+
   grunt.registerMultiTask('node-inspector', 'Runs node-inspector to debug your node.js JavaScripts', function () {
     var options = this.options();
     var done = this.async();
     var args = [require.resolve('node-inspector/bin/inspector')];
+    var pushArg = function(option, val) {
+      args.push('--' + option);
+      args.push(val);
+    };
     [
-      'web-port',
-      'web-host',
       'debug-port',
+      'web-host',
+      'web-port',
       'save-live-edit',
-      'readTimeout',
+      'preload',
+      'hidden',
       'stack-trace-limit',
-      'no-preload',
-      'hidden'
+      'ssl-key',
+      'ssl-cert'
     ].forEach(function (option) {
-      if (option in options) {
-        args.push('--' + option);
-        if (option === 'hidden') {
-          args.push(JSON.stringify(options[option]));
-          return;
+      if(option in options) {
+        if(util.isArray(options[option])) {
+          options[option].forEach(function(val) {
+            pushArg(option, val);
+          });
+        } else {
+          pushArg(option, options[option]);
         }
-        args.push(options[option]);
       }
     });
 


### PR DESCRIPTION
- Fixed `hidden` option parsing, so multiple `hidden` options can be defined.
- Swapped `no-preload` for `preload` option (breaking change).
- Add SSL options.
- Bump to 0.4.0 (on account of breaking change).